### PR TITLE
Prop for auto-placement of items list

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -94,7 +94,11 @@ export default {
     },
     placeholder: String,
     prepend: String,
-    append: String
+    append: String,
+    autoEstimatePlace: {
+      type: Boolean,
+      default: false
+    },
   },
 
   computed: {
@@ -120,6 +124,15 @@ export default {
     resizeList(el) {
       const rect = el.getBoundingClientRect()
       const listStyle = this.$refs.list.$el.style
+      
+      if(this.autoEstimatePlace) {
+        const firstHalfOfScreen = rect.y < (screen.availHeight / 2);
+        if (!firstHalfOfScreen) {
+          listStyle.top = this.$refs.list.$el.offsetHeight * (-1) + 'px';
+        } else {
+          listStyle.top = "";
+        }
+      }
 
       // Set the width of the list on resize
       listStyle.width = rect.width + 'px'


### PR DESCRIPTION
When typeahead input is on bottom of page and user open typeahead hints, many of them are out of screen.
This is my solution of this problem.

When input is on first 50% of viewport height, list displays as always to the bottom but when input is on second 50% of viewport height, list goes above the input.

Thank you for your involvement in open-source solutions and I'll be glad if you find my PR helpful.